### PR TITLE
fix: menghilangkan .env.example dari navigasi webnya

### DIFF
--- a/index.php
+++ b/index.php
@@ -192,7 +192,7 @@ if (!is_dir(rewritePath($pageUrl))) {
                             'composer.lock',
                             'phpcs.xml',
                             '.env',
-                            'env',
+                            '.env.example',
                             '.gitignore',
                             '.htaccess',
                             'autoload.php',


### PR DESCRIPTION
Closes <!-- mention issue yang ingin kamu tutup dengan PR ini -->
<!-- Contoh: Closes #1 -->

## Deskripsi (Description)

<!-- deskripsikan tentang perubahan yang kamu berikan -->
- [ ] saya menambahkan materi basic baru
- [ ] saya memperbaiki materi basic yang sudah ada
- [ ] saya menambahkan materi utility baru
- [ ] saya memperbaiki materi utility sudah ada
- [ ] saya menambahkan dokumentasi/artikel baru
- [ ] saya memperbaiki dokumentasi/artikel yang sudah ada
- [ ] saya menambahkan algoritma baru
- [ ] saya memperbaiki algoritma yang sudah ada
- [x] saya memperbaiki navigasi websitenya

## Contributor Requirements (Syarat Kontributor)

- [x] saya sudah membaca _(I have read)_ [CONTRIBUTING](https://github.com/bellshade/PHP/blob/main/CONTRIBUTING.md) dan sudah menyetujui semua
- [ ] saya telah menambahkan docstring yang memberikan penjelasan maksud dari kode yang saya buat
- [ ] saya sudah membuat artikel `README.md` tentang materi yang saya buat
- [ ] saya menggunakan bahasa indonesia untuk memberikan penjelasan dari kode yang saya buat

## Environment

saya menggunakan (I am using):

- `os` = `windows`

## Testing

- [x] Codesniffer PSR-12 `phpcs`
- [x] Codesniffer autofix `phpcbf`
- [ ] Unit testing PHPUnit

## Maintainer
<!-- request maintainer untuk mereiview kode kamu
usahakan kamu memilih sesuai apa yang telah kamu ubah
**maintainer PHP**
@bellshade/php-team

**maintainer dokumentasi**
@bellshade/docs-team
-->
**maintainer PHP**
@bellshade/php-team


<!-- jika ada gagal pada salah satu test kami akan mengeceknya kembali -->
<!-- if there is a failure in one of the tests we will check it again -->
